### PR TITLE
updates checkout, go, go-setup versions, adds new commit

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,11 +15,11 @@ jobs:
       TWITTER_TOKEN_SECRET: ${{ secrets.TWITTER_TOKEN_SECRET }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
-    - name: Set up Go 1.14
-      uses: actions/setup-go@v1
+      uses: actions/checkout@v3
+    - name: Set up Go 1.19
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.14
+        go-version: 1.19
     - name: Fetch blocked accounts
       run: go run . -- blocks > ../blocked_accounts.txt
     - name: Fetch muted accounts
@@ -29,12 +29,10 @@ jobs:
     - name: Fetch followers
       run: go run . -- followers > ../followers.txt
     - name: Commit results
-      run: |
-        set -e
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "github-actions[bot]"
-
-        d="$(date --rfc-3339=s)"
-        git add --all
-        git commit --allow-empty -m "Periodic update: $d"
-        git push origin master
+      uses: EndBug/add-and-commit@v9
+      with:
+        committer_name: GitHub Actions
+        committer_email: 41898282+github-actions[bot]@users.noreply.github.com
+        fetch: false
+        message: update-${{ env.GITHUB_RUN_NUMBER }}
+        add: "*.txt --force"


### PR DESCRIPTION
Love the simplicity of this approach. Thanks! 
Few version updates (e.g. go update address known vulnerabilities):
* `actions/checkout` from `v2` to `v3`
* `actions/setup-go` from `v1` to `v3` 
* `go` from `v1.14` to `v1.19`

Swaps bash script on result commit to `EndBug/add-and-commit@v9` action and commit message with incremental run number 